### PR TITLE
Check whether any entity is stepping carefully.

### DIFF
--- a/common/src/main/java/com/diontryban/sneak_through_berries/mixin/SweetBerryBushBlockMixin.java
+++ b/common/src/main/java/com/diontryban/sneak_through_berries/mixin/SweetBerryBushBlockMixin.java
@@ -22,7 +22,6 @@ package com.diontryban.sneak_through_berries.mixin;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.BushBlock;

--- a/common/src/main/java/com/diontryban/sneak_through_berries/mixin/SweetBerryBushBlockMixin.java
+++ b/common/src/main/java/com/diontryban/sneak_through_berries/mixin/SweetBerryBushBlockMixin.java
@@ -21,6 +21,7 @@ package com.diontryban.sneak_through_berries.mixin;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BonemealableBlock;
@@ -46,10 +47,8 @@ public abstract class SweetBerryBushBlockMixin extends BushBlock implements Bone
             Entity entity,
             CallbackInfo ci
     ) {
-        if (entity instanceof Player player) {
-            if (player.isShiftKeyDown()) {
-                ci.cancel();
-            }
+        if (entity.isSteppingCarefully() && entity instanceof LivingEntity) {
+            ci.cancel();
         }
     }
 }


### PR DESCRIPTION
The logic behind sneak stepping, while it exists through `Entity#isShiftKeyDown`, is actually delegated through another method called `Entity#isSteppingCarefully`. This is normally what is called to determine whether the entity should be sneaking over blocks. As such, this also applies to other entities as well, as it is implemented on the base class.

This PR mirrors the logic used to step carefully on a magma block, allowing any living entity that is 'stepping carefully' to bypass the sweet berry bush block. This, by default, does not affect any other entities except the cat, which has its own logic for stepping carefully; however, as it can be tamed, I feel it is reasonable that the cat can step carefully through the berry bush.